### PR TITLE
Fix uru nupkg download URL

### DIFF
--- a/uber-ruby-installer.ps1
+++ b/uber-ruby-installer.ps1
@@ -54,10 +54,10 @@ if (-not (Test-Path -Path $devKit2_32)) {
 # URU
 if (-not (Test-Path -Path "$($ENV:ChocolateyInstall)\bin\uru.ps1")) {
   Write-Output "Installing URU..."
-  $downloadURL = 'https://bitbucket.org/jonforums/uru/downloads/uru.0.8.4.nupkg'
+  $downloadURL = 'https://bitbucket.org/jonforums/uru/downloads/uru.0.8.5.nupkg'
   $uruRoot = 'C:\Tools'
   $uruInstall = Join-Path -Path $uruRoot -ChildPath 'URUInstall'
-  $uruInstallNuget = Join-Path -Path $uruInstall -ChildPath 'uru.0.8.3.nupkg'
+  $uruInstallNuget = Join-Path -Path $uruInstall -ChildPath 'uru.0.8.5.nupkg'
   if (Test-Path -Path $uruInstall) { Remove-Item -Path $uruInstall -Force -Recurse -Confirm:$false | Out-Null }
   New-Item -Path $uruInstall -ItemType Directory | Out-Null
   Write-Output "Downloading URU installer..."


### PR DESCRIPTION
It looks like the downloads page that the script is pointing at no longer has the 0.8.4 version available. The current script throws a 404 when it tries to download uru.