### PR TITLE
Update uber

### DIFF
--- a/uber-ruby-installer.ps1
+++ b/uber-ruby-installer.ps1
@@ -80,7 +80,7 @@ $response.Links | ? { $_.href -match '/ruby-.+-mingw32.7z$'} | % {
 }
 Write-Host "Getting list of available older ruby installs ..."
 $response = Invoke-WebRequest -Uri 'http://rubyinstaller.org/downloads/archives'
-$response.Links | ? { $_.href -match '/ruby-.+-mingw32.7z$'} | % {
+$response.Links | ? { $_.href -match '(/ruby-.+-mingw32.7z$|/rubyinstaller-.+-(x64|x86)\.7z$)'} | % {
   try {
     $rubyVersions.Add( ($_.innerHTML -replace 'Ruby ',''), $_.href )
   } catch {

--- a/uber-ruby-installer.ps1
+++ b/uber-ruby-installer.ps1
@@ -54,7 +54,7 @@ if (-not (Test-Path -Path $devKit2_32)) {
 # URU
 if (-not (Test-Path -Path "$($ENV:ChocolateyInstall)\bin\uru.ps1")) {
   Write-Output "Installing URU..."
-  $downloadURL = 'https://bitbucket.org/jonforums/uru/downloads/uru.0.8.4.nupkg'
+  $downloadURL = 'https://bitbucket.org/jonforums/uru/downloads/uru.0.8.5.nupkg'
   $uruRoot = 'C:\Tools'
   $uruInstall = Join-Path -Path $uruRoot -ChildPath 'URUInstall'
   $uruInstallNuget = Join-Path -Path $uruInstall -ChildPath 'uru.0.8.3.nupkg'


### PR DESCRIPTION
These commits make minor fixes and updates to the uber installer for Ruby.

Namely:

1. Updating the uru download URI to point to the latest release as `0.8.4` now results in a 404 error.
2. Updating the matching regex for ruby installer downloads to grab the latest releases as the uri string has changed.

These changes were tested locally but informally.